### PR TITLE
Use LinuxTimer to drive RateGroups for nasa/fprime#3651

### DIFF
--- a/SystemReference/Top/Main.cpp
+++ b/SystemReference/Top/Main.cpp
@@ -57,8 +57,8 @@ int main(int argc, char* argv[]) {
     SystemReference::setup(state);
 
     // register signal handlers to exit program
-    signal(SIGINT,sighandler);
-    signal(SIGTERM,sighandler);
+    signal(SIGINT,signalHandler);
+    signal(SIGTERM,signalHandler);
 
     SystemReference::linuxTimer.startTimer(1000);
     SystemReference::teardown(state);

--- a/SystemReference/Top/Main.cpp
+++ b/SystemReference/Top/Main.cpp
@@ -21,7 +21,7 @@ void stopCycle() {
 }
 
 static void signalHandler(int signum) {
-    stopSimulatedCycle();
+    stopCycle();
 }
 
 int main(int argc, char* argv[]) {
@@ -60,8 +60,8 @@ int main(int argc, char* argv[]) {
     signal(SIGINT,sighandler);
     signal(SIGTERM,sighandler);
 
-    SystemReference::linuxTimer.startTimer(interval.getSeconds()*1000+interval.getUSeconds()/1000);
-    SystemReference::teardownTopology(inputs);
+    SystemReference::linuxTimer.startTimer(1000);
+    SystemReference::teardown(state);
 
     (void) printf("Exiting...\n");
 

--- a/SystemReference/Top/Main.cpp
+++ b/SystemReference/Top/Main.cpp
@@ -16,16 +16,12 @@ SystemReference::TopologyState state;
 // Enable the console logging provided by Os::Log
 Os::Console logger;
 
-void stopSimulatedCycle() {
-    linuxTimer.quit();
+void stopCycle() {
+    SystemReference::linuxTimer.quit();
 }
 
 static void signalHandler(int signum) {
     stopSimulatedCycle();
-}
-
-void startSimulatedCycle(Fw::TimeInterval interval) {
-    linuxTimer.startTimer(interval.getSeconds()*1000+interval.getUSeconds()/1000);
 }
 
 int main(int argc, char* argv[]) {
@@ -64,7 +60,7 @@ int main(int argc, char* argv[]) {
     signal(SIGINT,sighandler);
     signal(SIGTERM,sighandler);
 
-    SystemReference::startSimulatedCycle(Fw::TimeInterval(1, 0));  // Program loop cycling rate groups at 1Hz
+    SystemReference::linuxTimer.startTimer(interval.getSeconds()*1000+interval.getUSeconds()/1000);
     SystemReference::teardownTopology(inputs);
 
     (void) printf("Exiting...\n");

--- a/SystemReference/Top/SystemReferenceTelemetryPackets.fppi
+++ b/SystemReference/Top/SystemReferenceTelemetryPackets.fppi
@@ -36,10 +36,6 @@ telemetry packets SystemReferencePackets {
         SystemReference.fileManager.Errors
     }
 
-    packet DriveTlm id 3 group 1 {
-        SystemReference.blockDrv.BD_Cycles
-    }
-
     packet SystemResources1 id 5 group 2 {
         SystemReference.systemResources.MEMORY_TOTAL
         SystemReference.systemResources.MEMORY_USED

--- a/SystemReference/Top/SystemReferenceTopologyDefs.hpp
+++ b/SystemReference/Top/SystemReferenceTopologyDefs.hpp
@@ -1,7 +1,6 @@
 #ifndef SystemReferenceTopologyDefs_HPP
 #define SystemReferenceTopologyDefs_HPP
 
-#include "Drv/BlockDriver/BlockDriver.hpp"
 #include "Fw/Types/MallocAllocator.hpp"
 #include "SystemReference/Top/FppConstantsAc.hpp"
 #include "Svc/FramingProtocol/FprimeProtocol.hpp"

--- a/SystemReference/Top/SystemReferenceTopologyDefs.hpp
+++ b/SystemReference/Top/SystemReferenceTopologyDefs.hpp
@@ -40,7 +40,6 @@ namespace SystemReference {
 
   // Health ping entries
   namespace PingEntries {
-    namespace SystemReference_blockDrv { enum { WARN = 3, FATAL = 5 }; }
     namespace SystemReference_chanTlm { enum { WARN = 3, FATAL = 5 }; }
     namespace SystemReference_cmdDisp { enum { WARN = 3, FATAL = 5 }; }
     namespace SystemReference_cmdSeq { enum { WARN = 3, FATAL = 5 }; }

--- a/SystemReference/Top/instances.fpp
+++ b/SystemReference/Top/instances.fpp
@@ -16,11 +16,6 @@ module SystemReference {
   # Active component instances
   # ----------------------------------------------------------------------
 
-  instance blockDrv: Drv.BlockDriver base id 0x0100 \
-    queue size Default.queueSize \
-    stack size Default.stackSize \
-    priority 140
-
   instance rateGroup1Comp: Svc.ActiveRateGroup base id 0x0200 \
     queue size Default.queueSize \
     stack size Default.stackSize \
@@ -461,5 +456,5 @@ module SystemReference {
 
   instance fprimeRouter: Svc.FprimeRouter base id 0x4F00
 
-
+  instance linuxTimer: Svc.LinuxTimer base id 0x5000
 }

--- a/SystemReference/Top/topology.fpp
+++ b/SystemReference/Top/topology.fpp
@@ -22,7 +22,6 @@ module SystemReference {
     # ----------------------------------------------------------------------
 
     instance $health
-    instance blockDrv
 
     instance cmdDisp
     instance cmdSeq
@@ -53,6 +52,7 @@ module SystemReference {
     instance imuI2cBus
     instance camera
     instance saveImageBufferLogger
+    instance linuxTimer
 
     # ----------------------------------------------------------------------
     # Pattern graph specifiers
@@ -112,8 +112,8 @@ module SystemReference {
 
     connections RateGroups {
 
-      # Block driver
-      blockDrv.CycleOut -> rateGroupDriverComp.CycleIn
+      # Linux Timer to drive rate groups
+      linuxTimer.CycleOut -> rateGroupDriverComp.CycleIn
 
       # Rate group 1
       rateGroupDriverComp.CycleOut[Ports_RateGroups.rateGroup1] -> rateGroup1Comp.CycleIn
@@ -132,8 +132,7 @@ module SystemReference {
       # Rate group 3
       rateGroupDriverComp.CycleOut[Ports_RateGroups.rateGroup3] -> rateGroup3Comp.CycleIn
       rateGroup3Comp.RateGroupMemberOut[0] -> $health.Run
-      rateGroup3Comp.RateGroupMemberOut[1] -> blockDrv.Sched
-      rateGroup3Comp.RateGroupMemberOut[2] -> comBufferManager.schedIn
+      rateGroup3Comp.RateGroupMemberOut[1] -> comBufferManager.schedIn
     }
 
     connections Sequencer {


### PR DESCRIPTION
Use LinuxTimer to drive RateGroups instead of BlockDrv #3651